### PR TITLE
parch: schema updates

### DIFF
--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -138,14 +138,19 @@ export const installers = pgTable(
 
 /**
  * Download Events table - for tracking download analytics
+ * Supports both artifact downloads (updates) and installer downloads.
+ * Either artifactId or installerId should be set, but not both.
  */
 export const downloadEvents = pgTable(
   "download_events",
   {
     id: text("id").primaryKey(),
+    // For update downloads (Tauri updater)
     artifactId: text("artifact_id")
-      .notNull()
       .references(() => artifacts.id, { onDelete: "cascade" }),
+    // For installer downloads (standalone installers)
+    installerId: text("installer_id")
+      .references(() => installers.id, { onDelete: "cascade" }),
     appId: text("app_id")
       .notNull()
       .references(() => apps.id, { onDelete: "cascade" }),
@@ -159,6 +164,7 @@ export const downloadEvents = pgTable(
   },
   (table) => [
     index("download_events_artifact_id_idx").on(table.artifactId),
+    index("download_events_installer_id_idx").on(table.installerId),
     index("download_events_app_id_idx").on(table.appId),
     index("download_events_downloaded_at_idx").on(table.downloadedAt),
     index("download_events_platform_idx").on(table.platform),

--- a/server/src/routes/public.ts
+++ b/server/src/routes/public.ts
@@ -117,13 +117,14 @@ publicRoutes.get("/:app_slug/update/:target/:current_version", async (c) => {
   if (result.hasUpdate) {
     // Record the download event asynchronously (non-blocking)
     const ipCountry = extractCountryFromHeaders((name) => c.req.header(name));
-    recordDownloadAsync(
-      result.metadata.artifactId,
-      result.metadata.appId,
-      result.metadata.platform,
-      result.metadata.version,
-      ipCountry
-    );
+    recordDownloadAsync({
+      artifactId: result.metadata.artifactId,
+      appId: result.metadata.appId,
+      platform: result.metadata.platform,
+      version: result.metadata.version,
+      ipCountry,
+      downloadType: "update",
+    });
 
     // Return the Tauri update response directly (not wrapped in our API response format)
     // Tauri expects the raw response format
@@ -179,13 +180,14 @@ publicRoutes.get(
     if (result.hasUpdate) {
       // Record the download event asynchronously (non-blocking)
       const ipCountry = extractCountryFromHeaders((name) => c.req.header(name));
-      recordDownloadAsync(
-        result.metadata.artifactId,
-        result.metadata.appId,
-        result.metadata.platform,
-        result.metadata.version,
-        ipCountry
-      );
+      recordDownloadAsync({
+        artifactId: result.metadata.artifactId,
+        appId: result.metadata.appId,
+        platform: result.metadata.platform,
+        version: result.metadata.version,
+        ipCountry,
+        downloadType: "update",
+      });
 
       return c.json(result.response, 200);
     }
@@ -397,14 +399,14 @@ publicRoutes.get("/:app_slug/download/:platform", async (c) => {
 
   // Record the download event asynchronously
   const ipCountry = extractCountryFromHeaders((name) => c.req.header(name));
-  recordDownloadAsync(
-    installer.id,
-    app.id,
-    matchedPlatform,
-    latestRelease.version,
+  recordDownloadAsync({
+    installerId: installer.id,
+    appId: app.id,
+    platform: matchedPlatform,
+    version: latestRelease.version,
     ipCountry,
-    "installer"
-  );
+    downloadType: "installer",
+  });
 
   // Return JSON or redirect based on format query param
   if (formatJson) {
@@ -501,14 +503,14 @@ publicRoutes.get("/:app_slug/download/:platform/:version", async (c) => {
 
   // Record the download event asynchronously
   const ipCountryVersioned = extractCountryFromHeaders((name) => c.req.header(name));
-  recordDownloadAsync(
-    versionedInstaller.id,
-    app.id,
-    versionedMatchedPlatform,
-    release.version,
-    ipCountryVersioned,
-    "installer"
-  );
+  recordDownloadAsync({
+    installerId: versionedInstaller.id,
+    appId: app.id,
+    platform: versionedMatchedPlatform,
+    version: release.version,
+    ipCountry: ipCountryVersioned,
+    downloadType: "installer",
+  });
 
   // Return JSON or redirect based on format query param
   if (formatJson) {

--- a/server/src/services/analytics.service.ts
+++ b/server/src/services/analytics.service.ts
@@ -34,34 +34,43 @@ export class ArtifactNotFoundForAnalyticsError extends Error {
 export type DownloadType = "update" | "installer";
 
 /**
+ * Options for recording a download event.
+ */
+export interface RecordDownloadOptions {
+  /** The ID of the artifact (for update downloads) */
+  artifactId?: string;
+  /** The ID of the installer (for installer downloads) */
+  installerId?: string;
+  /** The ID of the app */
+  appId: string;
+  /** The target platform (e.g., "darwin-aarch64") */
+  platform: string;
+  /** The version being downloaded */
+  version: string;
+  /** Optional ISO country code from CDN headers */
+  ipCountry?: string;
+  /** Type of download: 'update' or 'installer' */
+  downloadType: DownloadType;
+}
+
+/**
  * Records a download event for analytics tracking.
  *
  * Called when a Tauri client receives an update response or when an installer is downloaded.
  * Does not block the response - errors are logged but not thrown.
  *
- * @param artifactId - The ID of the artifact or installer being downloaded
- * @param appId - The ID of the app
- * @param platform - The target platform (e.g., "darwin-aarch64")
- * @param version - The version being downloaded
- * @param ipCountry - Optional ISO country code from CDN headers
- * @param downloadType - Type of download: 'update' (default) or 'installer'
+ * @param options - The download event options
  */
-export async function recordDownload(
-  artifactId: string,
-  appId: string,
-  platform: string,
-  version: string,
-  ipCountry?: string,
-  downloadType: DownloadType = "update"
-): Promise<void> {
+export async function recordDownload(options: RecordDownloadOptions): Promise<void> {
   const newEvent: NewDownloadEvent = {
     id: ulid(),
-    artifactId,
-    appId,
-    platform,
-    version,
-    ipCountry: ipCountry ?? null,
-    downloadType,
+    artifactId: options.artifactId ?? null,
+    installerId: options.installerId ?? null,
+    appId: options.appId,
+    platform: options.platform,
+    version: options.version,
+    ipCountry: options.ipCountry ?? null,
+    downloadType: options.downloadType,
     downloadedAt: new Date(),
   };
 
@@ -72,25 +81,14 @@ export async function recordDownload(
  * Records a download event asynchronously without blocking.
  * Errors are logged but do not affect the calling code.
  *
- * @param artifactId - The ID of the artifact or installer being downloaded
- * @param appId - The ID of the app
- * @param platform - The target platform
- * @param version - The version being downloaded
- * @param ipCountry - Optional ISO country code
- * @param downloadType - Type of download: 'update' (default) or 'installer'
+ * @param options - The download event options
  */
-export function recordDownloadAsync(
-  artifactId: string,
-  appId: string,
-  platform: string,
-  version: string,
-  ipCountry?: string,
-  downloadType: DownloadType = "update"
-): void {
-  recordDownload(artifactId, appId, platform, version, ipCountry, downloadType).catch((error) => {
+export function recordDownloadAsync(options: RecordDownloadOptions): void {
+  recordDownload(options).catch((error) => {
     console.error("Failed to record download event:", error);
   });
 }
+
 
 /**
  * Validates that an app exists by ID.


### PR DESCRIPTION
This pull request updates how download events are tracked in the analytics system to support both artifact (update) and installer downloads. The changes introduce a more flexible schema in the database, refactor the analytics service to use a single options object, and update all usage sites to the new API. This improves clarity, maintainability, and allows for more accurate analytics.

**Database schema updates:**
- The `download_events` table now supports both artifact and installer downloads by adding a nullable `installerId` column, and making `artifactId` nullable. Only one of these should be set per event. An index on `installerId` was also added for efficient querying. [[1]](diffhunk://#diff-bd0b95a7f37276a62c1ace51647a0e0eb4d377c4725508f32837655a572b9c18R141-R153) [[2]](diffhunk://#diff-bd0b95a7f37276a62c1ace51647a0e0eb4d377c4725508f32837655a572b9c18R167)

**Analytics service refactor:**
- The `recordDownload` and `recordDownloadAsync` functions in `analytics.service.ts` now accept a single `RecordDownloadOptions` object, which includes all relevant fields for both artifact and installer downloads. This replaces the previous positional parameter API and makes the code easier to use and extend. [[1]](diffhunk://#diff-be6af632b2a643ff847f76c52b0a5e2388452a9be819d543f54fe7b26d548962R36-R73) [[2]](diffhunk://#diff-be6af632b2a643ff847f76c52b0a5e2388452a9be819d543f54fe7b26d548962L75-R92)

**Route handler updates:**
- All calls to `recordDownloadAsync` in `public.ts` routes have been updated to use the new options object, passing the correct fields for either artifact or installer downloads. This ensures download events are recorded accurately for both update and installer scenarios. [[1]](diffhunk://#diff-0696ff93e56ad6e7bd8d2599e07b3bbecf08c4eb69ccd303f5d6245de102ca44L120-R127) [[2]](diffhunk://#diff-0696ff93e56ad6e7bd8d2599e07b3bbecf08c4eb69ccd303f5d6245de102ca44L182-R190) [[3]](diffhunk://#diff-0696ff93e56ad6e7bd8d2599e07b3bbecf08c4eb69ccd303f5d6245de102ca44L400-R409) [[4]](diffhunk://#diff-0696ff93e56ad6e7bd8d2599e07b3bbecf08c4eb69ccd303f5d6245de102ca44L504-R513)